### PR TITLE
feat: use external url to resolve the path for error pages

### DIFF
--- a/ee/identity-federation/api/oidc/idp-login/[fedAppId].ts
+++ b/ee/identity-federation/api/oidc/idp-login/[fedAppId].ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 import jackson from '@lib/jackson';
 import { OIDCIdPInitiatedReq } from '@boxyhq/saml-jackson';
-import { setErrorCookie } from '@lib/utils';
+import { setErrorCookieAndRedirect } from '@lib/utils';
 import { logger } from '@lib/logger';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -31,8 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } catch (err: any) {
     logger.error(err, 'OIDC IdP initiated login error');
     const { message, statusCode = 500 } = err;
-    // set error in cookie redirect to error page
-    setErrorCookie(res, { message, statusCode }, { path: '/error' });
-    res.redirect(302, '/error');
+
+    setErrorCookieAndRedirect(res, { message, statusCode });
   }
 }

--- a/ee/identity-federation/api/sso.ts
+++ b/ee/identity-federation/api/sso.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import jackson from '@lib/jackson';
-import { setErrorCookie } from '@lib/utils';
+import { setErrorCookieAndRedirect } from '@lib/utils';
 import { logger } from '@lib/logger';
 
 type SAMLRequest = {
@@ -31,8 +31,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } catch (err: any) {
     logger.error(err, 'SAML Federation authorize error');
     const { message, statusCode = 500 } = err;
-    setErrorCookie(res, { message, statusCode }, { path: '/error' });
-    res.redirect(302, '/error');
+
+    setErrorCookieAndRedirect(res, { message, statusCode });
   }
 }
 

--- a/pages/api/oauth/authorize.ts
+++ b/pages/api/oauth/authorize.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 import jackson from '@lib/jackson';
 import { OAuthReq } from '@boxyhq/saml-jackson';
-import { setErrorCookie } from '@lib/utils';
+import { setErrorCookieAndRedirect } from '@lib/utils';
 import { logger } from '@lib/logger';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -28,8 +28,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } catch (err: any) {
     logger.error(err, 'Authorize error');
     const { message, statusCode = 500 } = err;
-    // set error in cookie redirect to error page
-    setErrorCookie(res, { message, statusCode }, { path: '/error' });
-    res.redirect(302, '/error');
+
+    setErrorCookieAndRedirect(res, { message, statusCode });
   }
 }

--- a/pages/api/oauth/oidc.ts
+++ b/pages/api/oauth/oidc.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import jackson from '@lib/jackson';
-import { setErrorCookie } from '@lib/utils';
+import { setErrorCookieAndRedirect } from '@lib/utils';
 import { OIDCAuthzResponsePayload } from '@boxyhq/saml-jackson';
 import { logger } from '@lib/logger';
 
@@ -31,8 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } catch (err: any) {
     const { message, statusCode = 500 } = err;
     logger.error(err, 'Error processing OIDC IdP response');
-    // set error in cookie redirect to error page
-    setErrorCookie(res, { message, statusCode }, { path: '/error' });
-    res.redirect(302, '/error');
+
+    setErrorCookieAndRedirect(res, { message, statusCode });
   }
 }

--- a/pages/api/oauth/saml.ts
+++ b/pages/api/oauth/saml.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import jackson from '@lib/jackson';
-import { setErrorCookie } from '@lib/utils';
+import { setErrorCookieAndRedirect } from '@lib/utils';
 import { logger } from '@lib/logger';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -50,8 +50,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { message, statusCode = 500 } = err;
     logger.error(err, 'Error processing SAML IdP response:');
 
-    setErrorCookie(res, { message, statusCode }, { path: '/error' });
-
-    res.redirect(302, '/error');
+    setErrorCookieAndRedirect(res, { message, statusCode });
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Error page is always assumed to be at `/error`, but if external url contains a path then this no longer holds true. This PR fixes that and append `error` to external url.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Updated dependencies
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Existing unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
